### PR TITLE
問題一覧画面の実装

### DIFF
--- a/app/CorrectAnswer.php
+++ b/app/CorrectAnswer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CorrectAnswer extends Model
+{
+    protected $fillable = ['questions_id', 'answer'];
+}

--- a/app/Http/Controllers/ListController.php
+++ b/app/Http/Controllers/ListController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class ListController extends Controller
+{
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    /**
+     * Show the application dashboard.
+     *
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function index()
+    {
+        return view('list');
+    }
+}

--- a/app/Http/Controllers/ListController.php
+++ b/app/Http/Controllers/ListController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Question;
 
 class ListController extends Controller
 {
@@ -23,6 +24,7 @@ class ListController extends Controller
      */
     public function index()
     {
-        return view('list');
+        $questions = Question::all();
+        return view('list')->with('questions', $questions);
     }
 }

--- a/app/Http/Controllers/ListController.php
+++ b/app/Http/Controllers/ListController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Question;
+use App\CorrectAnswer;
 
 class ListController extends Controller
 {
@@ -25,6 +26,10 @@ class ListController extends Controller
     public function index()
     {
         $questions = Question::all();
-        return view('list')->with('questions', $questions);
+        $answers = CorrectAnswer::all();
+        return view('list')->with([
+            'questions' => $questions,
+            'answers' => $answers,
+        ]);
     }
 }

--- a/app/Question.php
+++ b/app/Question.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Question extends Model
+{
+    protected $fillable = ['id', 'question'];
+}

--- a/public/css/list.css
+++ b/public/css/list.css
@@ -19,11 +19,15 @@
 }
 
 .list {
-	margin:20px 200px;
+	margin:20px 300px;
+}
+
+.list .question-tbl {
+	margin-top: 15px;
 }
 
 .list .textbox{
-	width: 500px;
+	width: 380px;
 }
 
 .list button {

--- a/public/css/list.css
+++ b/public/css/list.css
@@ -1,0 +1,33 @@
+@charset "UTF-8";
+.py-4 {
+	margin: 20px;
+}
+
+.register {
+	margin: 0.25rem 1.25rem;
+	padding: 0.5rem 1.25rem;
+	background-color: rgba(0, 0, 0, 0.03);
+	border: 1px solid rgba(0, 0, 0, 0.125);
+	border-radius: 0.25rem;
+	width: 200px;
+	text-align: center;
+	margin: 0 auto;
+}
+
+.register a {
+	color: black;
+}
+
+.list {
+	margin:20px 200px;
+}
+
+.list .textbox{
+	width: 500px;
+}
+
+.list button {
+	border: 1px solid rgba(0, 0, 0, 0.125);
+	background-color: rgba(0, 0, 0, 0.03);
+
+}

--- a/public/css/top.css
+++ b/public/css/top.css
@@ -2,12 +2,19 @@
 
 .top-menue {
 	margin-bottom: 20px;
+	list-style: none;
+
 }
 
-.top-menue button {
+.top-menue li {
 	margin: 0.25rem 1.25rem;
 	padding: 0.5rem 1.25rem;
 	background-color: rgba(0, 0, 0, 0.03);
 	border: 1px solid rgba(0, 0, 0, 0.125);
 	border-radius: 0.25rem;
+	width: 450px;
+}
+
+.top-menue a {
+	color: black;
 }

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,5 +1,10 @@
+<!doctype html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+<link href="{{ asset('css/top.css') }}" rel="stylesheet">
+</head>
+<body>
 @extends('layouts.app')
-
 @section('content')
 <div class="container">
     <div class="row justify-content-center">
@@ -18,23 +23,20 @@
                     You are logged in!
                 </div>
 
-                <div class="top-menue">
+                <ul class="top-menue">
 
-					<form action="list.php" method="post">
-						<button type="submit">問題と答えを確認・登録する ＞</button>
-					</form>
+                	<li><a href="{{ action('ListController@index') }}">問題と答えを確認・登録する ＞</a></li>
 
-					<form action="test.php" method="post">
-						<button type="submit">テストをする ＞</button>
-					</form>
+                	<li><a href="">テストをする ＞</a></li>
 
-					<form action="history.php" method="post">
-						<button type="submit">過去の採点結果をみる ＞</button>
-					</form>
+                	<li><a href="">過去の採点結果をみる ＞</a></li>
+				</ul>
 
-				</div>
             </div>
         </div>
     </div>
 </div>
 @endsection
+
+</body>
+</html>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -24,9 +24,10 @@
     <div id="app">
         <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
             <div class="container">
-                <a class="navbar-brand" href="{{ url('/') }}">
-                    {{ config('app.name', 'LaravelApp') }}
-                </a>
+<!--             使用しないのでコメントアウト -->
+<!--                 <a class="navbar-brand" href="{{ url('/') }}"> -->
+<!--                     {{ config('app.name', 'LaravelApp') }} -->
+<!--                 </a> -->
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
                     <span class="navbar-toggler-icon"></span>
                 </button>

--- a/resources/views/layouts/app_top.blade.php
+++ b/resources/views/layouts/app_top.blade.php
@@ -50,6 +50,9 @@
                                 </li>
                             @endif
                         @else
+                        	<li class="nav-item">
+                        		<a class="nav-link" href="{{ route('home') }}">{{ __('Top') }}</a>
+                        	</li>
                             <li class="nav-item dropdown">
                                 <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
                                     {{ Auth::user()->name }} <span class="caret"></span>

--- a/resources/views/list.blade.php
+++ b/resources/views/list.blade.php
@@ -12,33 +12,46 @@
 
 <div class="list">
 	@foreach ($questions as $question)
-	<table>
-		<tr>
-			<th>問題:</th>
+		<table class="question-tbl">
+			<tr>
+				<th>問題:</th>
 
-			<!-- 問題馬号 -->
-			<td>{{ $question->id }}</td>
+				<!-- 問題馬号 -->
+				<td>{{ $question->id }}</td>
 
-			<!-- 問題 -->
-			<td class="textbox">{{ $question->question }}</td>
+				<!-- 問題 -->
+				<td class="textbox">{{ $question->question }}</td>
 
-			<!-- 編集ボタン -->
-			<td>
-				<form action="edit.blade.php" method="post">
-					<button type="submit">編集</button>
-				</form>
-			</td>
+				<!-- 編集ボタン -->
+				<td>
+					<form action="edit.blade.php" method="post">
+						<button type="submit">編集</button>
+					</form>
+				</td>
 
-			<!-- 削除ボタン -->
-			<td>
-				<form action="delete_confirm.blade.php" method="post">
-					<button type="submit">削除</button>
-				</form>
-			</td>
+				<!-- 削除ボタン -->
+				<td>
+					<form action="delete_confirm.blade.php" method="post">
+						<button type="submit">削除</button>
+					</form>
+				</td>
 
-		</tr>
+			</tr>
+		</table>
+
+        <!-- 答え -->
+		@foreach ($answers as $answer)
+			@if ($answer->questions_id == $question->id)
+    		<table>
+    			<tr>
+    				<th>答え:</th>
+    				<td class="textbox">{{ $answer->answer }}</td>
+    			</tr>
+    		</table>
+			@endif
 		@endforeach
-	</table>
+	@endforeach
 </div>
-
 @endsection
+</body>
+</html>

--- a/resources/views/list.blade.php
+++ b/resources/views/list.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts.app_top')
+
+@section('content')
+
+<p>ああああ</p>
+
+@endsection

--- a/resources/views/list.blade.php
+++ b/resources/views/list.blade.php
@@ -1,7 +1,44 @@
+<!doctype html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+<link href="{{ asset('css/list.css') }}" rel="stylesheet">
+</head>
+<body>
 @extends('layouts.app_top')
-
 @section('content')
+<div class="register">
+	<a href="">新規登録</a>
+</div>
 
-<p>ああああ</p>
+<div class="list">
+	@foreach ($questions as $question)
+	<table>
+		<tr>
+			<th>問題:</th>
+
+			<!-- 問題馬号 -->
+			<td>{{ $question->id }}</td>
+
+			<!-- 問題 -->
+			<td class="textbox">{{ $question->question }}</td>
+
+			<!-- 編集ボタン -->
+			<td>
+				<form action="edit.blade.php" method="post">
+					<button type="submit">編集</button>
+				</form>
+			</td>
+
+			<!-- 削除ボタン -->
+			<td>
+				<form action="delete_confirm.blade.php" method="post">
+					<button type="submit">削除</button>
+				</form>
+			</td>
+
+		</tr>
+		@endforeach
+	</table>
+</div>
 
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,3 +18,5 @@ Route::get('/', function () {
 Auth::routes();
 
 Route::get('/home', 'HomeController@index')->name('home');
+
+Route::get('/list', 'ListController@index')->name('list');


### PR DESCRIPTION
## 問題一覧画面
<img width="1196" alt="スクリーンショット 2021-05-02 1 55 40" src="https://user-images.githubusercontent.com/65025904/116789382-83c8aa00-aae9-11eb-8bf5-3a5e7e2eaadf.png">

## questionsテーブルの内容
<img width="308" alt="スクリーンショット 2021-05-02 1 52 21" src="https://user-images.githubusercontent.com/65025904/116789343-567bfc00-aae9-11eb-9afb-5677d8966765.png">

## correct_answersテーブルの内容
<img width="315" alt="スクリーンショット 2021-05-02 1 52 30" src="https://user-images.githubusercontent.com/65025904/116789355-6b588f80-aae9-11eb-9e39-62942d33ff6c.png">
