### PR TITLE
採点結果履歴画面の実装

### DIFF
--- a/app/Http/Controllers/HistoryController.php
+++ b/app/Http/Controllers/HistoryController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\History;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\User;
+
+class HistoryController extends Controller
+{
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    /**
+     * 履歴画面へ移動
+     */
+    public function index()
+    {
+        $auths = Auth::id();
+
+        $history = History::where('users_id', $auths)->get();
+
+        $user = User::where('id', $auths)->get();
+
+        return view('history')->with([
+            'history' => $history,
+            'user_name' => $user[0]['name']
+        ]);
+    }
+}

--- a/app/Http/Controllers/HistoryController.php
+++ b/app/Http/Controllers/HistoryController.php
@@ -24,11 +24,11 @@ class HistoryController extends Controller
      */
     public function index()
     {
-        $auths = Auth::id();
+        $user_id = Auth::id();
 
-        $history = History::where('users_id', $auths)->get();
+        $history = History::where('users_id', $user_id)->get();
 
-        $user = User::where('id', $auths)->get();
+        $user = User::where('id', $user_id)->get();
 
         return view('history')->with([
             'history' => $history,

--- a/app/Http/Controllers/TestController.php
+++ b/app/Http/Controllers/TestController.php
@@ -93,7 +93,7 @@ class TestController extends Controller
         // --------------------------------------------------
         $data = [
             'users_id' => Auth::id(),
-            'point' => $point,
+            'point' => $score,
             'created_at' => Carbon::now()
         ];
 

--- a/public/css/history.css
+++ b/public/css/history.css
@@ -1,0 +1,24 @@
+@charset "UTF-8";
+
+.py-4 {
+	margin: 20px;
+}
+
+.title {
+	text-align: center;
+	margin-bottom: 50px;
+}
+
+.history {
+	margin: 0 auto;
+	width: 35%;
+}
+
+th {
+	width: 10%;
+	height: 30px;
+}
+
+td {
+	height: 30px;
+}

--- a/resources/views/history.blade.php
+++ b/resources/views/history.blade.php
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+<link href="{{ asset('css/history.css') }}" rel="stylesheet">
+</head>
+<body>
+@extends('layouts.app_top')
+@section('content')
+<div class="history">
+	<h3 class="title">履歴</h3>
+
+		<table border = 1>
+			<tr>
+				<th>氏名</th>
+				<th>得点</th>
+				<th>採点時間</th>
+			</tr>
+
+			@foreach ($history as $h)
+			<tr>
+				<td>{{ $user_name }}</td>
+				<td>{{ $h->point }}</td>
+				<td>{{ $h->created_at }}</td>
+			</tr>
+			@endforeach
+		</tabel>
+
+</div>
+@endsection
+</body>
+</html

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -31,7 +31,7 @@
 
                 	<li><a href="{{ route('test.test') }}">テストをする ＞</a></li>
 
-                	<li><a href="">過去の採点結果をみる ＞</a></li>
+                	<li><a href="{{ route('history') }}">過去の採点結果をみる ＞</a></li>
 
 					@if ($admin == 1)
                 	<li><a href="">ユーザを追加・編集する　＞</a></li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,3 +35,5 @@ Route::post('/edit/update', 'EditController@update')->name('edit.update');
 
 Route::get('/test/test', 'TestController@test')->name('test.test');
 Route::post('/test/result', 'TestController@result')->name('test.result');
+
+Route::get('/history', 'HistoryController@index')->name('history');


### PR DESCRIPTION
### DBに登録されたデータ
<img width="281" alt="スクリーンショット 2021-05-11 17 16 17" src="https://user-images.githubusercontent.com/65025904/117782725-ddb13880-b27c-11eb-86bd-3b74f7e50a53.png">

### id: 1の履歴画面
<img width="1341" alt="スクリーンショット 2021-05-11 17 17 37" src="https://user-images.githubusercontent.com/65025904/117782916-0c2f1380-b27d-11eb-9a15-19cdd0564785.png">

### id: 2の履歴画面
<img width="1338" alt="スクリーンショット 2021-05-11 17 17 00" src="https://user-images.githubusercontent.com/65025904/117782962-14874e80-b27d-11eb-9319-c1f858af704a.png">

